### PR TITLE
gvfs-gdu-volume-monitor: Add missing build dependency on GTK

### DIFF
--- a/recipes-gnome/gvfs/gvfs-gdu-volume-monitor_git.bb
+++ b/recipes-gnome/gvfs/gvfs-gdu-volume-monitor_git.bb
@@ -2,7 +2,7 @@ require gvfs.inc
 
 BPN = "gvfs"
 
-DEPENDS = "gvfs gnome-disk-utility libgnome-keyring intltool-native"
+DEPENDS = "gtk+ gvfs gnome-disk-utility libgnome-keyring intltool-native"
 
 # we need gdu files only: reduce files to delete in libexecdir
 EXTRA_OECONF += "--disable-gphoto2 \


### PR DESCRIPTION
Fixes errors like
git/daemon/gvfsbackendrecent.c:15:21: fatal error: gtk/gtk.h: No such
file or directory
|  #include <gtk/gtk.h>

Signed-off-by: Khem Raj raj.khem@gmail.com
